### PR TITLE
Refactor pages logic

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,12 +44,17 @@ module.exports = (nextConfig = {}) => {
         use: '@svgr/webpack'
       })
 
-
       config.module.rules.push({
         test: /\.mdx?$/,
         use: [options.defaultLoaders.babel, require.resolve('./mdx-loader'), require.resolve('./search-loader')]
       })
 
+      // `import '@primer/bluebprints/meta'`
+      const metaPath = require.resolve('../meta')
+      config.module.rules.push({
+        test: new RegExp(`^${metaPath}$`),
+        use: 'val-loader'
+      })
 
       configured = true
       if (typeof nextConfig.webpack === 'function') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,6 +51,10 @@ module.exports = (nextConfig = {}) => {
 
       // `import '@primer/bluebprints/meta'`
       const metaPath = require.resolve('../meta')
+      config.resolve.alias = Object.assign({
+        '@primer/blueprints/meta': metaPath
+      }, config.resolve.alias)
+
       config.module.rules.push({
         test: new RegExp(`^${metaPath}$`),
         use: 'val-loader'

--- a/lib/meta-runtime.template.js
+++ b/lib/meta-runtime.template.js
@@ -1,0 +1,48 @@
+/**
+ * XXX This file is a *template* for generating the runtime
+ * "@primer/blueprints/meta" endpoint.
+ */
+
+const pageTree = PAGE_TREE_JSON
+
+const pageList = []
+const pageMap = new Map()
+
+walkPages(page => {
+  pageList.push(page)
+  pageMap.set(page.path, page)
+})
+
+export {
+  pageList,
+  pageMap,
+  pageTree,
+  walkPages,
+  getFirstPage
+}
+
+function walkPages(visitor) {
+  return visit(pageTree, visitor)
+}
+
+function visit(page, visitor, ...rest) {
+  let value = visitor(page, ...rest)
+  if (value !== false) {
+    for (const child of page.children) {
+      value = visit(child, visitor, ...rest)
+      if (value === false) break
+    }
+  }
+  return value
+}
+
+function getFirstPage(test) {
+  let first
+  walkPages((page, ...rest) => {
+    if (test(page, ...rest)) {
+      first = page
+      return false
+    }
+  })
+  return first
+}

--- a/lib/meta-runtime.template.js
+++ b/lib/meta-runtime.template.js
@@ -3,6 +3,7 @@
  * "@primer/blueprints/meta" endpoint.
  */
 
+// eslint-disable-next-line no-unused-vars
 const pageTree = PAGE_TREE_JSON
 
 const pageList = []
@@ -13,13 +14,7 @@ walkPages(page => {
   pageMap.set(page.path, page)
 })
 
-export {
-  pageList,
-  pageMap,
-  pageTree,
-  walkPages,
-  getFirstPage
-}
+export {pageList, pageMap, pageTree, walkPages, getFirstPage}
 
 function walkPages(visitor) {
   return visit(pageTree, visitor)

--- a/lib/meta-runtime.template.js
+++ b/lib/meta-runtime.template.js
@@ -24,7 +24,7 @@ function visit(page, visitor, ...rest) {
   let value = visitor(page, ...rest)
   if (value !== false) {
     for (const child of page.children) {
-      value = visit(child, visitor, ...rest)
+      value = visit(child, visitor, page, ...rest)
       if (value === false) break
     }
   }

--- a/meta.js
+++ b/meta.js
@@ -1,0 +1,124 @@
+/**
+ * XXX this file is intended to be processed with val-loader!
+ *
+ * It exports an object with a "code" string that's bundled as-is,
+ * and should not be used directly in other environments.
+ */
+const globby = require('globby')
+const matter = require('gray-matter')
+const {dirname, join, parse: parsePath} = require('path')
+const {readFileSync} = require('fs')
+
+const INDEX_PATTERN = /\/index[^\/]*$/
+const RUNTIME_TEMPLATE_PATH = require.resolve('./lib/meta-runtime.template')
+
+module.exports = () => {
+  // FIXME: get this from the config?
+  const pageExtensions = ['md', 'mdx']
+
+  // FIXME: get this from... next?
+  const pagesDir = join(process.cwd(), 'pages')
+  // console.warn(`loading pages from: ${pagesDir}`)
+
+  const globs = [
+    '!node_modules',
+    ...pageExtensions.map(ext => `**/*.${ext}`)
+  ]
+  // console.warn(`page globs: ${globs.join(', ')}`)
+
+  return globby(globs, {cwd: pagesDir})
+    .then(pagePaths => {
+      const pages = pagePaths.map(path => {
+        const file = join(pagesDir, path)
+        const page = loadPage(file)
+        return Object.assign(page, {
+          path: getURLPathForFile(path),
+          requirePath: './' + path,
+          file
+        })
+      })
+
+      return {
+        cacheable: true,
+        dependencies: [RUNTIME_TEMPLATE_PATH, ...pages.map(page => page.file)],
+        code: getCodeForPages(pages)
+      }
+    })
+}
+
+function loadPage(path) {
+  const buffer = readFileSync(path)
+  const {data, excerpt, content} = matter(buffer, {excerpt: true})
+  return {path, meta: data, excerpt}
+}
+
+function getPathMap(pages) {
+  const map = {}
+  for (const page of pages) {
+    const {path} = page
+    if (map[path]) {
+      throw new Error(`Duplicate path for page: ${page.file} (existing: ${map[path].file})`)
+    }
+    const parts = removePrefix(path, '/').split('/')
+    parts.pop()
+    page.parent = `/${parts.join('/')}`
+    page.children = []
+
+    map[path] = page
+  }
+  return map
+}
+
+function getPageTree(map) {
+  const pages = Object.values(map)
+  let root = map['/']
+  if (root) {
+    delete root.parent
+  } else {
+    pages.sort((a, b) => a.path.localeCompare(b.path))
+    root = pages[0]
+  }
+
+  // remove root from the list of nodes
+  const nodes = pages.slice()
+  nodes.splice(nodes.indexOf(root), 1)
+
+  const orphans = []
+  for (const node of nodes) {
+    const parent = map[node.parent]
+    if (parent) {
+      parent.children.push(node)
+    } else {
+      orphans.push(node)
+    }
+  }
+
+  if (orphans.length) {
+    // eslint-disable-next-line no-console
+    console.warn(`unable to nest ${orphans.length} pages: ${orphans.map(node => node.file).join(', ')}`)
+    root.orphans = orphans
+  }
+
+  return root
+}
+
+function getCodeForPages(pages) {
+  const pageMap = getPathMap(pages)
+  const pageTree = getPageTree(pageMap)
+  const template = readFileSync(RUNTIME_TEMPLATE_PATH, 'utf8')
+  const code = template.replace(/PAGE_TREE_JSON/g, JSON.stringify(pageTree))
+  return code // + `\nconsole.log('page map:', ${JSON.stringify(pageMap)})`
+}
+
+function removePrefix(str, prefix) {
+  if (str.indexOf(prefix) === 0) {
+    return str.substr(prefix.length)
+  } else {
+    return str
+  }
+}
+
+function getURLPathForFile(path) {
+  let {dir, name} = parsePath(path)
+  return name === 'index' ? join('/', dir) : join('/', dir, name)
+}

--- a/now.json
+++ b/now.json
@@ -13,6 +13,7 @@
   "files": [
     ".babelrc",
     "lib",
+    "meta.js",
     "next.config.js",
     "package-lock.json",
     "pages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,7 +1408,6 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
       "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2033,8 +2032,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.0",
@@ -3562,8 +3560,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4389,8 +4386,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -4414,8 +4410,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4512,12 +4507,6 @@
         "make-dir": "^1.0.0",
         "pkg-dir": "^2.0.0"
       }
-    },
-    "find-insert-index": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/find-insert-index/-/find-insert-index-0.0.1.tgz",
-      "integrity": "sha1-Fs00ZkwqwjOQWrKzl0W87HITYt4=",
-      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -4712,7 +4701,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4733,12 +4723,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4753,17 +4745,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4880,7 +4875,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4892,6 +4888,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4906,6 +4903,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4913,12 +4911,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4937,6 +4937,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5017,7 +5018,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5029,6 +5031,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5114,7 +5117,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5150,6 +5154,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5169,6 +5174,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5212,12 +5218,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6802,8 +6810,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6944,7 +6951,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
@@ -6955,7 +6961,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -7405,12 +7410,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
     },
-    "mergesort": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mergesort/-/mergesort-0.0.1.tgz",
-      "integrity": "sha1-Nk7MMbKX3H9E5RHTZRdvHDnQj8I=",
-      "dev": true
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -7509,8 +7508,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -9217,8 +9215,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -11695,16 +11692,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "tree-model": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tree-model/-/tree-model-1.0.7.tgz",
-      "integrity": "sha512-oP4LUbCVtD2gcjcRaeI4L5hY60tHzB+AK/bthIJ2Pq1EUUOio5/xFzPWnGoBZlhtqpqbOkhFDzKIwKLOn0kccQ==",
-      "dev": true,
-      "requires": {
-        "find-insert-index": "0.0.1",
-        "mergesort": "0.0.1"
-      }
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -12324,7 +12311,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -12386,6 +12372,31 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "val-loader": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/val-loader/-/val-loader-1.1.1.tgz",
+      "integrity": "sha512-JLqLXJWCVLXTxbUeHhLpWkgl3+X3U8Bl0vY7rTFZgFSbLJaEtAxuD2ixy/cM8w/gzC7sS3NE5IDSzClDt332sw==",
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.5"
+      },
+      "dependencies": {
+        "ajv-keywords": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+          "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
+        },
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "rollup-plugin-babel": "4.0.0-beta.8",
     "rollup-plugin-commonjs": "9.1.3",
     "title-case": "^2.1.1",
-    "tree-model": "^1.0.7",
     "typographic-base": "^1.0.4",
     "unist-util-select": "^2.0.0",
     "unist-util-stringify-position": "^2.0.0",
@@ -71,8 +70,8 @@
     "@githubprimer/octicons-react": "^8.1.3",
     "@primer/components": "12.0.1",
     "clipboard-copy-element": "^0.5.0",
-    "execa": "1.0.0",
     "downshift": "3.2.7",
+    "execa": "1.0.0",
     "globby": "9.1.0",
     "lunr": "2.3.6",
     "prism-github": "^1.1.0",
@@ -83,6 +82,7 @@
     "slugify": "1.3.4",
     "styled-components": "4.1.3",
     "styled-system": "4.0.4",
-    "uuid": "3.3.2"
+    "uuid": "3.3.2",
+    "val-loader": "1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   ],
   "files": [
     "dist",
+    "lib",
+    "meta.js",
     "src"
   ],
   "author": "GitHub, Inc.",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prebuild": "npm run dist",
     "now-build": "next build",
     "now-start": "next start",
+    "now-test": "npm run now-build && npm run now-start",
     "predist": "rm -rf dist",
     "dist": "NODE_ENV=production rollup -c",
     "prepublishOnly": "npm run dist",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,10 +4,10 @@ import {MDXProvider} from '@mdx-js/tag'
 import {withMDXLive} from 'mdx-live'
 import documents from '../searchIndex'
 import Head from 'next/head'
+import {pageMap} from '@primer/blueprints/meta'
 import * as primerComponents from '@primer/components'
 import * as docsComponents from '../src/components'
 import {config} from '../src/utils'
-import {pageMap} from '../meta'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 const {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,9 @@ import documents from '../searchIndex'
 import Head from 'next/head'
 import * as primerComponents from '@primer/components'
 import * as docsComponents from '../src/components'
-import {config, requirePage, rootPage} from '../src/utils'
+import {config} from '../src/utils'
+import {pageMap} from '../meta'
+import {join} from 'path'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 const {
@@ -52,26 +54,27 @@ function getComponents(page = {}) {
   }
 }
 
+const requirePage = require.context('.', true, /\.(js|md)x?$/)
+
 export default class MyApp extends App {
   static async getInitialProps({Component, ctx}) {
-    let page = {}
+    let initialProps = {}
 
     if (Component.getInitialProps) {
-      page = await Component.getInitialProps(ctx)
+      initialProps = await Component.getInitialProps(ctx)
     }
 
-    return {page}
+    return {initialProps}
   }
 
   render() {
     // strip the trailing slash
     const pathname = this.props.router.pathname.replace(/\/$/, '')
-    const {Component, page} = this.props
+    const {Component, initialProps} = this.props
 
-    const node = rootPage.first(node => node.path === pathname) || {}
-    const {file, meta = {}} = node || {}
-
-    const Hero = file ? requirePage(file).Hero : null
+    const page = pageMap.get(pathname) || {}
+    const {meta = {}, requirePath} = page
+    const Hero = requirePath ? requirePage(requirePath).Hero : null
 
     return (
       <BaseStyles fontSize={2} style={{fontFamily: theme.fonts.normal}}>
@@ -98,8 +101,8 @@ export default class MyApp extends App {
               <Box color="gray.9" maxWidth={['auto', 'auto', 'auto', CONTENT_MAX_WIDTH]} px={6} mx="auto" my={6}>
                 <div className="markdown-body">
                   {!meta.hero && meta.title ? <MarkdownHeading>{meta.title}</MarkdownHeading> : null}
-                  <MDXProvider components={getComponents(node)}>
-                    <Component {...page} />
+                  <MDXProvider components={getComponents(page)}>
+                    <Component {...initialProps} />
                   </MDXProvider>
                   {config.production ? null : (
                     <details>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,7 +8,6 @@ import * as primerComponents from '@primer/components'
 import * as docsComponents from '../src/components'
 import {config} from '../src/utils'
 import {pageMap} from '../meta'
-import {join} from 'path'
 import {CONTENT_MAX_WIDTH} from '../src/constants'
 
 const {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ export default [
   {
     input: 'src/index.js',
     plugins,
+    external: ['@primer/blueprints'],
     output: formats.map(format => ({
       file: `dist/index.${format}.js`,
       format,

--- a/src/NavList.js
+++ b/src/NavList.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {pageMap} from '../meta'
+import {pageMap} from '@primer/blueprints/meta'
 import {nodeSort} from './utils'
 import NavLink from './NavLink'
 import SectionLink from './SectionLink'

--- a/src/NavList.js
+++ b/src/NavList.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import {rootPage, nodeSort} from './utils'
+import {pageMap} from '../meta'
+import {nodeSort} from './utils'
 import NavLink from './NavLink'
 import SectionLink from './SectionLink'
 
@@ -9,7 +10,7 @@ import SectionLink from './SectionLink'
  * of the node's children.
  */
 export default function NavList({path}) {
-  const node = rootPage.first(node => node.path === path)
+  const node = pageMap.get(path)
   const children = node ? node.children.sort(nodeSort) : []
   return (
     <>

--- a/src/PageLink.js
+++ b/src/PageLink.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from './Link'
-import {pageMap} from '../meta'
+import {pageMap} from '@primer/blueprints/meta'
 
 /**
  * The PageLink component takes an `href` and optional `children`.

--- a/src/PageLink.js
+++ b/src/PageLink.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import Link from './Link'
-import {rootPage} from './utils'
+import {pageMap} from '../meta'
 
 /**
  * The PageLink component takes an `href` and optional `children`.
  * If no `children` are provided, we look up the "node" of the corresponding
  * page in the tree (the one whose `path` matches the given `href`) and use
- * that node's `meta.title` if it's set. In other words, given the following
+ * that page's `meta.title` if it's set. In other words, given the following
  * pages/foo/bar.md:
  *
  * ```md
@@ -27,7 +27,10 @@ export default function PageLink(props) {
   if (content) {
     return <Link {...props} />
   }
-  const node = rootPage.first(node => node.path === href)
-  const children = (node ? node.meta.title : null) || href
+  const page = pageMap.get(href)
+  if (!page) {
+    console.warn(`no page for "${href}"`, pageMap.keys())
+  }
+  const children = (page ? page.meta.title : null) || href
   return <Link {...props}>{children}</Link>
 }

--- a/src/PageLink.js
+++ b/src/PageLink.js
@@ -29,6 +29,7 @@ export default function PageLink(props) {
   }
   const page = pageMap.get(href)
   if (!page) {
+    // eslint-disable-next-line no-console
     console.warn(`no page for "${href}"`, pageMap.keys())
   }
   const children = (page ? page.meta.title : null) || href

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import getConfig from 'next/config'
-import TreeModel from 'tree-model'
 import {join} from 'path'
 
 export const CommonStyles = () => {
@@ -10,82 +9,11 @@ export const CommonStyles = () => {
 
 export const CommonScripts = () => <script src={getAssetPath('github/styleguide.js')} />
 
-const INDEX_PATTERN = /\/index(\.[a-z]+)?$/
-
 export const config = getConfig().publicRuntimeConfig || {}
 
 export const assetPrefix = config.assetPrefix || ''
 export const assetPath = `${assetPrefix}/static/`
 export const getAssetPath = path => `${assetPath}${path}`
-
-const ext = /\.mdx?$/
-export const requirePage = require.context('../pages', true, /\.mdx?$/)
-export const pathMap = requirePage.keys().reduce((map, key) => {
-  const base = key.replace(ext, '').replace(/\/index$/, '')
-  const path = base.substr(1) // strip the leading "."
-  map[path] = key
-  return map
-}, {})
-
-const nested = nest(pathMap)
-export const pageTree = new TreeModel()
-export const rootPage = pageTree.parse(nested)
-
-rootPage.walk(node => {
-  const {model} = node
-  Object.assign(node, model)
-  if (node.file) {
-    const component = requirePage(node.file)
-    node.meta = component.frontMatter || {}
-    node.outline = component.tableOfContents
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn('no file for page node:', node.path)
-  }
-})
-
-function nest(map) {
-  const nodeMap = {}
-  const nodes = Object.keys(map)
-    .sort()
-    .map(path => {
-      const file = map[path]
-      const keys = path.substr(1).split('/')
-      return (nodeMap[path] = {
-        path,
-        file,
-        isIndex: INDEX_PATTERN.test(file),
-        parent: `/${keys.slice(0, keys.length - 1).join('/')}`,
-        children: []
-      })
-    })
-
-  let root = nodeMap['/']
-  if (!root) {
-    const sorted = nodes.sort((a, b) => a.path.localeCompare(b.path))
-    root = sorted[0]
-  }
-
-  // remove root from the list of nodes
-  nodes.splice(nodes.indexOf(root), 1)
-
-  const rest = []
-  for (const node of nodes) {
-    const parent = nodeMap[node.parent]
-    if (parent) {
-      parent.children.push(node)
-    } else {
-      rest.push(node)
-    }
-  }
-
-  if (rest.length) {
-    // eslint-disable-next-line no-console
-    console.warn('unable to nest some pages:', rest)
-  }
-
-  return root
-}
 
 export function sortCompare(a, b, get) {
   const aa = get(a)


### PR DESCRIPTION
This is part of #14 that should make the pages stuff work better in other repos, and may serve as a way to improve how we build the search index. Here's how it works:

1. In our Next.js configuration function, we add a module rule that tells Webpack to load our own [meta.js](https://github.com/primer/blueprints/blob/refactor-pages/meta.js) with [val-loader](https://github.com/webpack-contrib/val-loader).
1. The `val-loader` webpack loader _executes_ the function exported from `meta.js` (async), and injects the `code` of the returned object as the loader's source.
1. In our case, `meta.js` is getting the list of pages (Markdown or MDX only), parsing their frontmatter, and creating a tree data structure from the list of files that looks like:

    ```js
    {
      // the URL path
      path: '/',
      // the full path of the file
      file: '/path/to/cwd/pages/index.md',
      // the path relative to the pages dir, for require.context()
      requirePath: './index.md', 
      meta: {/* frontmatter */},
      children: [/* zero or more page objects */],
      // and some other properties
    }
    ```

1. The JSON string representation of that data structure is injected into the `PAGE_TREE_JSON` placeholder in [lib/meta-runtime.template.js](https://github.com/primer/blueprints/blob/refactor-pages/lib/meta-runtime.template.js), and the resulting code is returned as the "result" of the loader.

The result is that when you `import` or `require()` `@primer/blueprints/meta` **in webpack only, using our plugin**, you get the following named exports:

* `pageTree` is the tree data structure, as described above
* `pageMap` is a Map that you can query by path. i.e.: `pageMap.get(Router.pathname)`
* `pageList` is an Array of all the pages
* `walkPages(visitor)` "walks" the page tree (depth-first) with the visitor function: `visitor(page, ...ancestors)`
* `getFirstPage(test)` walks the page tree and returns the first page for which `test(page)` returns truthy

