### PR TITLE
Redirect export tweak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/blueprints",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Components for GitHub Documentation Sites",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,2 +1,2 @@
-import redirect from '../src/redirect'
+import {redirect} from '../src/redirect'
 export default redirect('/blueprints')

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -9,7 +9,7 @@ import Router from 'next/router'
  * export default redirect('/some/path')
  * ```
  */
-export default function redirect(uri, status = 303) {
+export function redirect(uri, status = 303) {
   // XXX this doesn't need to extend React.Component because
   // it doesn't "do" anything React-y
   return class {

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -10,8 +10,6 @@ import Router from 'next/router'
  * ```
  */
 export function redirect(uri, status = 303) {
-  // XXX this doesn't need to extend React.Component because
-  // it doesn't "do" anything React-y
   return class {
     static getInitialProps({res}) {
       // the "context" object passed to getInitialProps() will


### PR DESCRIPTION
This PR removes `redirect` as the default export in `redirect.js` so that it can be imported like any other export in blueprints aka `import {redirect} from '@primer/blueprints'`

Update version to 3.0.3