### PR TITLE
Fix opacity on syntax highlighting

### DIFF
--- a/src/CodeExampleStyles.js
+++ b/src/CodeExampleStyles.js
@@ -71,10 +71,6 @@ const styles = `
  .token.entity {
    cursor: help;
  }
-
- .namespace {
-   opacity: 0.7;
- }
 `
 
 export default styles


### PR DESCRIPTION
This PR removes the `namespace` class which adds 0.7 opacity to all the code 🤔 I am not 100% sure what that rule was there for in the first place, but it makes everything look horrible so I'm nixing it :) 