### PR TITLE
Lowercase heading ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/blueprints",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "description": "Components for GitHub Documentation Sites",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/pages/blueprints/content-components/markdown-heading.md
+++ b/pages/blueprints/content-components/markdown-heading.md
@@ -48,4 +48,5 @@ function getComponents() {
 
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |
-| as | String or Component | h1 | Sets the tag used in the Heading
+| as | String or Component | h1 | Sets the tag used in the Heading |
+| children | String | | Heading content should be a string in order for the automatic anchor linking to work |

--- a/src/MarkdownHeading.js
+++ b/src/MarkdownHeading.js
@@ -17,7 +17,7 @@ const StyledHeading = styled(Heading)`
   }
 `
 const MarkdownHeading = ({children, className, ...rest}) => {
-  const id = slugify(children.toString())
+  const id = slugify(children.toString(), {lower: true})
   return (
     <StyledHeading id={id} className={className} {...rest}>
       <Box as={Text} lineHeight={1} className="anchorWrapper" pr={1} ml={'-20px'} display={'none'}>

--- a/src/MarkdownHeading.js
+++ b/src/MarkdownHeading.js
@@ -29,7 +29,6 @@ const MarkdownHeading = ({children, className, ...rest}) => {
   )
 }
 
-
 MarkdownHeading.propTypes = {
   children: PropTypes.string
 }

--- a/src/MarkdownHeading.js
+++ b/src/MarkdownHeading.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 import {StyledOcticon, Heading, Box, Text} from '@primer/components'
 import {Link} from '@githubprimer/octicons-react'
 import slugify from 'slugify'
@@ -28,4 +29,8 @@ const MarkdownHeading = ({children, className, ...rest}) => {
   )
 }
 
+
+MarkdownHeading.propTypes = {
+  children: PropTypes.string
+}
 export default MarkdownHeading

--- a/src/MarkdownHeading.js
+++ b/src/MarkdownHeading.js
@@ -18,7 +18,7 @@ const StyledHeading = styled(Heading)`
   }
 `
 const MarkdownHeading = ({children, className, ...rest}) => {
-  const id = slugify(children.toString(), {lower: true})
+  const id = children ? slugify(children.toString(), {lower: true}) : ''
   return (
     <StyledHeading id={id} className={className} {...rest}>
       <Box as={Text} lineHeight={1} className="anchorWrapper" pr={1} ml={'-20px'} display={'none'}>


### PR DESCRIPTION
@simurai pointed out that the Table of Contents links were broken in primer/css because our `MarkdownHeading` component wasn't creating lower case id's, which remark/toc expects :) 

Bumps version to 4.0.2