### PR TITLE
Improvements to Copy Button

### DIFF
--- a/now.json
+++ b/now.json
@@ -13,7 +13,6 @@
   "files": [
     ".babelrc",
     "lib",
-    "meta.js",
     "next.config.js",
     "package-lock.json",
     "pages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/blueprints",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pages/blueprints/content-components/clipboard-copy.md
+++ b/pages/blueprints/content-components/clipboard-copy.md
@@ -8,13 +8,10 @@ The `value` prop must be provided with the current value of the code block.
 
 ```.jsx
 <ClipboardCopy value={'hihihi'}/>
-<br/>
-<ClipboardCopy as="link" value={'hihihi'}/>
 ```
 
 ## Component props
 
-| Name  | Type   | Default | Description                                                                                 |
-| :---- | :----- | :-----: | :------------------------------------------------------------------------------------------ |
-| value | String |         | The content that will be added to the user's clipboard when clicked.                        |
-| as    | String | button  | One of "button" or "link". Use `as="link"` when you want to put this button inside an input |
+| Name  | Type   | Default | Description                                                          |
+| :---- | :----- | :-----: | :------------------------------------------------------------------- |
+| value | String |         | The content that will be added to the user's clipboard when clicked. |

--- a/pages/blueprints/content-components/clipboard-copy.md
+++ b/pages/blueprints/content-components/clipboard-copy.md
@@ -8,12 +8,13 @@ The `value` prop must be provided with the current value of the code block.
 
 ```.jsx
 <ClipboardCopy value={'hihihi'}/>
-
+<br/>
+<ClipboardCopy as="link" value={'hihihi'}/>
 ```
-
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| value | String | | The content that will be added to the user's clipboard when clicked.
+| Name  | Type   | Default | Description                                                                                 |
+| :---- | :----- | :-----: | :------------------------------------------------------------------------------------------ |
+| value | String |         | The content that will be added to the user's clipboard when clicked.                        |
+| as    | String | button  | One of "button" or "link". Use `as="link"` when you want to put this button inside an input |

--- a/pages/blueprints/content-components/clipboard-copy.md
+++ b/pages/blueprints/content-components/clipboard-copy.md
@@ -8,10 +8,12 @@ The `value` prop must be provided with the current value of the code block.
 
 ```.jsx
 <ClipboardCopy value={'hihihi'}/>
+
 ```
+
 
 ## Component props
 
-| Name  | Type   | Default | Description                                                          |
-| :---- | :----- | :-----: | :------------------------------------------------------------------- |
-| value | String |         | The content that will be added to the user's clipboard when clicked. |
+| Name | Type | Default | Description |
+| :- | :- | :-: | :- |
+| value | String | | The content that will be added to the user's clipboard when clicked.

--- a/src/ClipboardCopy.js
+++ b/src/ClipboardCopy.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {findDOMNode} from 'react-dom'
-import {Button, Link, StyledOcticon} from '@primer/components'
+import {Button, StyledOcticon} from '@primer/components'
 import {Check, Clippy} from '@githubprimer/octicons-react'
 
 export default class ClipboardCopy extends React.Component {
@@ -50,27 +50,12 @@ export default class ClipboardCopy extends React.Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {value = '', as, ...rest} = this.props
+    const {value = ''} = this.props
 
-    const Icon = (
-      <StyledOcticon icon={this.state.copied ? Check : Clippy} color={this.state.copied ? 'green.5' : 'inherit'} />
+    return (
+      <Button onClick={this.onClick.bind(this)} type="button">
+        <StyledOcticon icon={this.state.copied ? Check : Clippy} color={this.state.copied ? 'green.5' : 'inherit'} />
+      </Button>
     )
-
-    if (as === 'link')
-      return (
-        <Link onClick={this.onClick.bind(this)} style={{cursor: 'pointer'}} {...rest}>
-          {Icon}
-        </Link>
-      )
-    else
-      return (
-        <Button onClick={this.onClick.bind(this)} type="button" {...rest}>
-          {Icon}
-        </Button>
-      )
   }
-}
-
-ClipboardCopy.defaultProps = {
-  as: 'button'
 }

--- a/src/ClipboardCopy.js
+++ b/src/ClipboardCopy.js
@@ -50,12 +50,27 @@ export default class ClipboardCopy extends React.Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {value = '', ...rest} = this.props
+    const {value = '', as, ...rest} = this.props
 
-    return (
-      <Button onClick={this.onClick.bind(this)} type="button" {...rest}>
-        <StyledOcticon icon={this.state.copied ? Check : Clippy} color={this.state.copied ? 'green.5' : 'inherit'} />
-      </Button>
+    const Icon = (
+      <StyledOcticon icon={this.state.copied ? Check : Clippy} color={this.state.copied ? 'green.5' : 'inherit'} />
     )
+
+    if (as === 'link')
+      return (
+        <Link onClick={this.onClick.bind(this)} style={{cursor: 'pointer'}} {...rest}>
+          {Icon}
+        </Link>
+      )
+    else
+      return (
+        <Button onClick={this.onClick.bind(this)} type="button" {...rest}>
+          {Icon}
+        </Button>
+      )
   }
+}
+
+ClipboardCopy.defaultProps = {
+  as: 'button'
 }

--- a/src/ClipboardCopy.js
+++ b/src/ClipboardCopy.js
@@ -1,9 +1,22 @@
 import React from 'react'
 import {findDOMNode} from 'react-dom'
-import {Button} from '@primer/components'
-import Octicon, {Clippy} from '@githubprimer/octicons-react'
+import {Button, Link, StyledOcticon} from '@primer/components'
+import {Check, Clippy} from '@githubprimer/octicons-react'
 
 export default class ClipboardCopy extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {copied: false}
+  }
+  onClick() {
+    this.copy()
+
+    /* set copied and reset it in 1.5s */
+    this.setState({copied: true})
+    window.setTimeout(() => {
+      this.setState({copied: false})
+    }, 1500)
+  }
   copy() {
     const {value = ''} = this.props
     const {clipboard} = window.navigator
@@ -38,9 +51,10 @@ export default class ClipboardCopy extends React.Component {
   render() {
     // eslint-disable-next-line no-unused-vars
     const {value = '', ...rest} = this.props
+
     return (
-      <Button onClick={() => this.copy()} type="button" {...rest}>
-        <Octicon icon={Clippy} />
+      <Button onClick={this.onClick.bind(this)} type="button" {...rest}>
+        <StyledOcticon icon={this.state.copied ? Check : Clippy} color={this.state.copied ? 'green.5' : 'inherit'} />
       </Button>
     )
   }


### PR DESCRIPTION
Realised, this already exists on .com today!

<img height="200px" src="https://user-images.githubusercontent.com/1863771/58324359-490d6000-7e44-11e9-9654-9a6e732d1439.gif"/>

I have a few doubts here

1. With primer-components, how do you set hover color for an icon inside `Link` (should Link do it for it's children)

2. Should I replicate the tooltip as well?
