### PR TITLE
Remove team link from the header

### DIFF
--- a/src/JumpNav.js
+++ b/src/JumpNav.js
@@ -18,9 +18,6 @@ const JumpNav = () => {
         <NavItem href="https://primer.style/css">Primer CSS</NavItem>
         <NavItem href="https://primer.style/components">Primer Components</NavItem>
       </NavDropdown>
-      <Link color="blue.2" mr={3} href="https://primer.style/team">
-        Team
-      </Link>
     </>
   )
 }


### PR DESCRIPTION
This will remove the header link to `/team`.

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/120486/58432641-0f468e80-80bc-11e9-8f5c-94b01305f4e2.png) | ![image](https://user-images.githubusercontent.com/120486/58432648-17063300-80bc-11e9-8917-6cad6ea97527.png) |

Fix #38